### PR TITLE
Fix https://github.com/kokkos/kokkos-tools/pull/213

### DIFF
--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -54,20 +54,19 @@ uint32_t getDeviceID(uint32_t devid_in) {
 void invoke_ktools_fence(uint32_t devID) {
   if (tpi_funcs.fence != nullptr) {
     if (tool_verbosity > 1) {
-      std::cout << "KokkosP: Sampler attempting to invoke"
-                   " tool-induced fence on device "
+      std::cout << "KokkosP: Sampler attempting to invoke tool-induced fence "
+                   "on device "
                 << getDeviceID(devID) << '\n';
     }
     (*(tpi_funcs.fence))(devID);
     if (tool_verbosity > 1) {
-      std::cout << "KokkosP: Sampler sucessfully invoked"
-                   " tool-induced fence on device "
+      std::cout << "KokkosP: Sampler sucessfully invoked tool-induced fence on "
+                   "device "
                 << getDeviceID(devID) << '\n';
     }
   } else {
-    std::cout
-        << "KokkosP: FATAL: Kokkos Tools Programming Interface's tool-invoked "
-           "Fence is NULL!\n";
+    std::cout << "KokkosP: FATAL: Kokkos Tools Programming Interface's "
+                 "tool-invoked Fence is NULL!\n";
   }
 }
 
@@ -76,8 +75,7 @@ void kokkosp_provide_tool_programming_interface(
   if (!num_funcs) {
     if (tool_verbosity > 0)
       std::cout << "KokkosP: Note: Number of functions in Tools Programming "
-                   "Interface "
-                   "is 0!\n";
+                   "Interface is 0!\n";
   }
   tpi_funcs = funcsFromTPI;
 }
@@ -103,9 +101,8 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 
   char* profileLibrary = getenv("KOKKOS_TOOLS_LIBS");
   if (NULL == profileLibrary) {
-    std::cout
-        << "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
-           "variable. Please use KOKKOS_TOOLS_LIBS\n";
+    std::cout << "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a "
+                 "deprecated variable. Please use KOKKOS_TOOLS_LIBS\n";
     profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
     if (NULL == profileLibrary) {
       std::cout << "KokkosP: No library to call in " << profileLibrary << '\n';
@@ -197,9 +194,7 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     srand(tool_seed);
     if (tool_verbosity > 0) {
       std::cout << "KokkosP: Seeding random number generator using seed "
-                << tool_seed
-                << " for "
-                   "random sampling.\n";
+                << tool_seed << " for random sampling.\n";
     }
   }
 
@@ -212,20 +207,15 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     tool_prob_num = atof(tool_probability);
     if (tool_prob_num > 100.0) {
       std::cout << "KokkosP: The sampling probability value is set to be "
-                   "greater than "
-                   "100.0. "
-                   "The probability for the sampler will be set to 100 "
-                   "percent; all of "
-                   "the "
-                   "invocations of a Kokkos kernel will be profiled.\n";
+                   "greater than 100.0. The probability for the sampler will "
+                   "be set to 100 percent; all of the invocations of a Kokkos "
+                   "kernel will be profiled.\n";
       tool_prob_num = 100.0;
     } else if (tool_prob_num < 0.0) {
       std::cout
           << "KokkosP: The sampling probability value is set to be a negative "
-             "number. The "
-             "sampler's probability will be set to 0 percent; none of the "
-             "invocations of "
-             "a Kokkos kernel will be profiled.\n";
+             "number. The sampler's probability will be set to 0 percent; none "
+             "of the invocations of a Kokkos kernel will be profiled.\n";
       tool_prob_num = 0.0;
     }
     if (tool_verbosity > 0) {
@@ -247,18 +237,16 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
   }
 
   if (tool_verbosity > 0) {
-    std::cout << "KokkosP: Neither the probability "
-                 "nor the skip rate for sampling were set...\n";
+    std::cout << "KokkosP: Neither the probability nor the skip rate for "
+                 "sampling were set...\n";
   }
   tool_prob_num    = 10.0;
   kernelSampleSkip = 1;
   if (tool_verbosity > 0) {
-    std::cout << "KokkosP: The probability "
-                 "for the sampler is set to the default of "
-              << tool_prob_num
-              << " percent. The skip rate "
-                 "for sampler"
-                 "will not be used.\n";
+    std::cout
+        << "KokkosP: The probability for the sampler is set to the default of "
+        << tool_prob_num
+        << " percent. The skip rate for sampler will not be used.\n";
   }
   kernelSampleSkip = 1;
 }

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -54,22 +54,20 @@ uint32_t getDeviceID(uint32_t devid_in) {
 void invoke_ktools_fence(uint32_t devID) {
   if (tpi_funcs.fence != nullptr) {
     if (tool_verbosity > 1) {
-      std::cout <<
-          "KokkosP: Sampler attempting to invoke"
-          " tool-induced fence on device " << 
-          getDeviceID(devID) << '\n';
+      std::cout << "KokkosP: Sampler attempting to invoke"
+                   " tool-induced fence on device "
+                << getDeviceID(devID) << '\n';
     }
     (*(tpi_funcs.fence))(devID);
     if (tool_verbosity > 1) {
-      std::cout <<
-          "KokkosP: Sampler sucessfully invoked"
-          " tool-induced fence on device " <<
-          getDeviceID(devID) << '\n';
+      std::cout << "KokkosP: Sampler sucessfully invoked"
+                   " tool-induced fence on device "
+                << getDeviceID(devID) << '\n';
     }
   } else {
-    std::cout <<
-        "KokkosP: FATAL: Kokkos Tools Programming Interface's tool-invoked "
-        "Fence is NULL!\n";
+    std::cout
+        << "KokkosP: FATAL: Kokkos Tools Programming Interface's tool-invoked "
+           "Fence is NULL!\n";
   }
 }
 
@@ -77,9 +75,9 @@ void kokkosp_provide_tool_programming_interface(
     uint32_t num_funcs, Kokkos_Tools_ToolProgrammingInterface funcsFromTPI) {
   if (!num_funcs) {
     if (tool_verbosity > 0)
-      std::cout <<
-          "KokkosP: Note: Number of functions in Tools Programming Interface "
-          "is 0!\n";
+      std::cout << "KokkosP: Note: Number of functions in Tools Programming "
+                   "Interface "
+                   "is 0!\n";
   }
   tpi_funcs = funcsFromTPI;
 }
@@ -105,9 +103,9 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 
   char* profileLibrary = getenv("KOKKOS_TOOLS_LIBS");
   if (NULL == profileLibrary) {
-    std::cout <<
-        "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
-        "variable. Please use KOKKOS_TOOLS_LIBS\n";
+    std::cout
+        << "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
+           "variable. Please use KOKKOS_TOOLS_LIBS\n";
     profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
     if (NULL == profileLibrary) {
       std::cout << "KokkosP: No library to call in " << profileLibrary << '\n';
@@ -127,7 +125,8 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
   nextLibrary = strtok(NULL, ";");
 
   if (NULL == nextLibrary) {
-    std::cout << "KokkosP: No child library to call in " << profileLibrary << '\n';
+    std::cout << "KokkosP: No child library to call in " << profileLibrary
+              << '\n';
     exit(-1);
   } else {
     if (tool_verbosity > 0) {
@@ -138,7 +137,8 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     void* childLibrary = dlopen(nextLibrary, RTLD_NOW | RTLD_GLOBAL);
 
     if (NULL == childLibrary) {
-      std::cerr << "KokkosP: Error: Unable to load: " << nextLibrary << " (Error=" << dlerror() << ")\n";
+      std::cerr << "KokkosP: Error: Unable to load: " << nextLibrary
+                << " (Error=" << dlerror() << ")\n";
       exit(-1);
     } else {
       beginForCallee =
@@ -167,18 +167,18 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 
       if (tool_verbosity > 0) {
         std::cout << "KokkosP: Function Status:\n";
-        std::cout << "KokkosP: begin-parallel-for:      " <<
-               ((beginForCallee == NULL) ? "no" : "yes")<< '\n';
-        std::cout << "KokkosP: begin-parallel-scan:     " <<
-               ((beginScanCallee == NULL) ? "no" : "yes")<< '\n';
-        std::cout << "KokkosP: begin-parallel-reduce:   " <<
-               ((beginReduceCallee == NULL) ? "no" : "yes")<< '\n';
-        std::cout << "KokkosP: end-parallel-for:        " <<
-               ((endForCallee == NULL) ? "no" : "yes")<< '\n';
-        std::cout << "KokkosP: end-parallel-scan:       " <<
-               ((endScanCallee == NULL) ? "no" : "yes")<< '\n';
-        std::cout << "KokkosP: end-parallel-reduce:     " <<
-               ((endReduceCallee == NULL) ? "no" : "yes") << '\n';
+        std::cout << "KokkosP: begin-parallel-for:      "
+                  << ((beginForCallee == NULL) ? "no" : "yes") << '\n';
+        std::cout << "KokkosP: begin-parallel-scan:     "
+                  << ((beginScanCallee == NULL) ? "no" : "yes") << '\n';
+        std::cout << "KokkosP: begin-parallel-reduce:   "
+                  << ((beginReduceCallee == NULL) ? "no" : "yes") << '\n';
+        std::cout << "KokkosP: end-parallel-for:        "
+                  << ((endForCallee == NULL) ? "no" : "yes") << '\n';
+        std::cout << "KokkosP: end-parallel-scan:       "
+                  << ((endScanCallee == NULL) ? "no" : "yes") << '\n';
+        std::cout << "KokkosP: end-parallel-reduce:     "
+                  << ((endReduceCallee == NULL) ? "no" : "yes") << '\n';
       }
     }
   }
@@ -190,16 +190,16 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
   if (0 > tool_seed) {
     srand(time(NULL));
     if (tool_verbosity > 0) {
-      std::cout <<
-          "KokkosP: Seeding random number generator using clock for "
-          "random sampling.\n";
+      std::cout << "KokkosP: Seeding random number generator using clock for "
+                   "random sampling.\n";
     }
   } else {
     srand(tool_seed);
     if (tool_verbosity > 0) {
-      std::cout <<
-          "KokkosP: Seeding random number generator using seed " << tool_seed << " for "
-          "random sampling.\n";
+      std::cout << "KokkosP: Seeding random number generator using seed "
+                << tool_seed
+                << " for "
+                   "random sampling.\n";
     }
   }
 
@@ -211,32 +211,34 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     //  Connector reasons about probability as a double between 0.0 and 1.0.
     tool_prob_num = atof(tool_probability);
     if (tool_prob_num > 100.0) {
-      std::cout <<
-          "KokkosP: The sampling probability value is set to be greater than "
-          "100.0. "
-          "The probability for the sampler will be set to 100 percent; all of "
-          "the "
-          "invocations of a Kokkos kernel will be profiled.\n";
+      std::cout << "KokkosP: The sampling probability value is set to be "
+                   "greater than "
+                   "100.0. "
+                   "The probability for the sampler will be set to 100 "
+                   "percent; all of "
+                   "the "
+                   "invocations of a Kokkos kernel will be profiled.\n";
       tool_prob_num = 100.0;
     } else if (tool_prob_num < 0.0) {
-      std::cout <<
-          "KokkosP: The sampling probability value is set to be a negative "
-          "number. The "
-          "sampler's probability will be set to 0 percent; none of the "
-          "invocations of "
-          "a Kokkos kernel will be profiled.\n";
+      std::cout
+          << "KokkosP: The sampling probability value is set to be a negative "
+             "number. The "
+             "sampler's probability will be set to 0 percent; none of the "
+             "invocations of "
+             "a Kokkos kernel will be profiled.\n";
       tool_prob_num = 0.0;
     }
     if (tool_verbosity > 0) {
-      std::cout << "KokkosP: Probability for the sampler set to: " << tool_prob_num << '\n';
-    }  
+      std::cout << "KokkosP: Probability for the sampler set to: "
+                << tool_prob_num << '\n';
+    }
     kernelSampleSkip = 1;
     return;
   }
 
   const char* tool_sample = getenv("KOKKOS_TOOLS_SAMPLER_SKIP");
   if (NULL != tool_sample) {
-    tool_prob_num = 100.0;
+    tool_prob_num    = 100.0;
     kernelSampleSkip = atoi(tool_sample) + 1;
     if (tool_verbosity > 0) {
       std::cout << "KokkosP: Sampling rate set to: " << tool_sample << '\n';
@@ -244,21 +246,21 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     return;
   }
 
-    if (tool_verbosity > 0) {
-      std::cout <<
-          "KokkosP: Neither the probability "
-          "nor the skip rate for sampling were set...\n";
-    }
-    tool_prob_num = 10.0;
-    kernelSampleSkip = 1;
-    if (tool_verbosity > 0) {
-      std::cout <<
-          "KokkosP: The probability "
-          "for the sampler is set to the default of " <<tool_prob_num <<" percent. The skip rate "
-          "for sampler"
-          "will not be used.\n";
-    }
-    kernelSampleSkip = 1;
+  if (tool_verbosity > 0) {
+    std::cout << "KokkosP: Neither the probability "
+                 "nor the skip rate for sampling were set...\n";
+  }
+  tool_prob_num    = 10.0;
+  kernelSampleSkip = 1;
+  if (tool_verbosity > 0) {
+    std::cout << "KokkosP: The probability "
+                 "for the sampler is set to the default of "
+              << tool_prob_num
+              << " percent. The skip rate "
+                 "for sampler"
+                 "will not be used.\n";
+  }
+  kernelSampleSkip = 1;
 }
 
 void kokkosp_finalize_library() {
@@ -271,9 +273,10 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
   static uint64_t invocationNum = 0;
   ++invocationNum;
   if ((invocationNum % kernelSampleSkip) == 0) {
-  if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
+    if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
       if (tool_verbosity > 0) {
-        std::cout << "KokkosP: sample " << *kID << " calling child-begin function...\n";
+        std::cout << "KokkosP: sample " << *kID
+                  << " calling child-begin function...\n";
       }
       if (NULL != beginForCallee) {
         if (tool_globFence) {
@@ -282,7 +285,8 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
         uint64_t nestedkID = 0;
         (*beginForCallee)(name, devID, &nestedkID);
         if (tool_verbosity > 0) {
-          std::cout << "KokkosP: sample " << *kID << " finished with child-begin function.\n";
+          std::cout << "KokkosP: sample " << *kID
+                    << " finished with child-begin function.\n";
         }
         infokIDSample.insert({*kID, nestedkID});
       }
@@ -291,11 +295,12 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
 }
 
 void kokkosp_end_parallel_for(const uint64_t kID) {
-if (NULL != endForCallee) {
- if (!(infokIDSample.find(kID) == infokIDSample.end())) {
+  if (NULL != endForCallee) {
+    if (!(infokIDSample.find(kID) == infokIDSample.end())) {
       uint64_t retrievedNestedkID = infokIDSample[kID];
       if (tool_verbosity > 0) {
-        std::cout << "KokkosP: sample " << kID << " calling child-end function...\n";
+        std::cout << "KokkosP: sample " << kID
+                  << " calling child-end function...\n";
       }
       if (tool_globFence) {
         invoke_ktools_fence(0);
@@ -314,7 +319,8 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
   if ((invocationNum % kernelSampleSkip) == 0) {
     if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
       if (tool_verbosity > 0) {
-        std::cout << "KokkosP: sample " << *kID << " calling child-begin function...\n";
+        std::cout << "KokkosP: sample " << *kID
+                  << " calling child-begin function...\n";
       }
       if (NULL != beginScanCallee) {
         uint64_t nestedkID = 0;
@@ -323,7 +329,8 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
         }
         (*beginScanCallee)(name, devID, &nestedkID);
         if (tool_verbosity > 0) {
-          std::cout << "KokkosP: sample " << *kID << " finished with child-begin function.\n";
+          std::cout << "KokkosP: sample " << *kID
+                    << " finished with child-begin function.\n";
         }
         infokIDSample.insert({*kID, nestedkID});
       }
@@ -336,7 +343,8 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
     if (!(infokIDSample.find(kID) == infokIDSample.end())) {
       uint64_t retrievedNestedkID = infokIDSample[kID];
       if (tool_verbosity > 0) {
-        std::cout << "KokkosP: sample " << kID << " calling child-end function...\n";
+        std::cout << "KokkosP: sample " << kID
+                  << " calling child-end function...\n";
       }
       if (tool_globFence) {
         invoke_ktools_fence(0);
@@ -355,7 +363,8 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
   if ((invocationNum % kernelSampleSkip) == 0) {
     if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
       if (tool_verbosity > 0) {
-        std::cout << "KokkosP: sample " << *kID << " calling child-begin function...\n";
+        std::cout << "KokkosP: sample " << *kID
+                  << " calling child-begin function...\n";
       }
       if (NULL != beginReduceCallee) {
         uint64_t nestedkID = 0;
@@ -364,7 +373,8 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
         }
         (*beginReduceCallee)(name, devID, &nestedkID);
         if (tool_verbosity > 0) {
-          std::cout << "KokkosP: sample " << *kID << " finished with child-begin function.\n";
+          std::cout << "KokkosP: sample " << *kID
+                    << " finished with child-begin function.\n";
         }
         infokIDSample.insert({*kID, nestedkID});
       }
@@ -377,7 +387,8 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
     if (!(infokIDSample.find(kID) == infokIDSample.end())) {
       uint64_t retrievedNestedkID = infokIDSample[kID];
       if (tool_verbosity > 0) {
-        std::cout << "KokkosP: sample " << kID << " calling child-end function...\n";
+        std::cout << "KokkosP: sample " << kID
+                  << " calling child-end function...\n";
       }
       if (tool_globFence) {
         invoke_ktools_fence(0);

--- a/common/kokkos-sampler/kp_sampler_skip.cpp
+++ b/common/kokkos-sampler/kp_sampler_skip.cpp
@@ -54,22 +54,22 @@ uint32_t getDeviceID(uint32_t devid_in) {
 void invoke_ktools_fence(uint32_t devID) {
   if (tpi_funcs.fence != nullptr) {
     if (tool_verbosity > 1) {
-      printf(
+      std::cout <<
           "KokkosP: Sampler attempting to invoke"
-          " tool-induced fence on device %d.\n",
-          getDeviceID(devID));
+          " tool-induced fence on device " << 
+          getDeviceID(devID) << '\n';
     }
     (*(tpi_funcs.fence))(devID);
     if (tool_verbosity > 1) {
-      printf(
+      std::cout <<
           "KokkosP: Sampler sucessfully invoked"
-          " tool-induced fence on device %d.\n",
-          getDeviceID(devID));
+          " tool-induced fence on device " <<
+          getDeviceID(devID) << '\n';
     }
   } else {
-    printf(
+    std::cout <<
         "KokkosP: FATAL: Kokkos Tools Programming Interface's tool-invoked "
-        "Fence is NULL!\n");
+        "Fence is NULL!\n";
   }
 }
 
@@ -77,9 +77,9 @@ void kokkosp_provide_tool_programming_interface(
     uint32_t num_funcs, Kokkos_Tools_ToolProgrammingInterface funcsFromTPI) {
   if (!num_funcs) {
     if (tool_verbosity > 0)
-      printf(
+      std::cout <<
           "KokkosP: Note: Number of functions in Tools Programming Interface "
-          "is 0!\n");
+          "is 0!\n";
   }
   tpi_funcs = funcsFromTPI;
 }
@@ -105,12 +105,12 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
 
   char* profileLibrary = getenv("KOKKOS_TOOLS_LIBS");
   if (NULL == profileLibrary) {
-    printf(
+    std::cout <<
         "Checking KOKKOS_PROFILE_LIBRARY. WARNING: This is a deprecated "
-        "variable. Please use KOKKOS_TOOLS_LIBS\n");
+        "variable. Please use KOKKOS_TOOLS_LIBS\n";
     profileLibrary = getenv("KOKKOS_PROFILE_LIBRARY");
     if (NULL == profileLibrary) {
-      printf("KokkosP: No library to call in %s\n", profileLibrary);
+      std::cout << "KokkosP: No library to call in " << profileLibrary << '\n';
       exit(-1);
     }
   }
@@ -127,19 +127,18 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
   nextLibrary = strtok(NULL, ";");
 
   if (NULL == nextLibrary) {
-    printf("KokkosP: No child library to call in %s\n", profileLibrary);
+    std::cout << "KokkosP: No child library to call in " << profileLibrary << '\n';
     exit(-1);
   } else {
     if (tool_verbosity > 0) {
-      printf("KokkosP: Next library to call: %s\n", nextLibrary);
-      printf("KokkosP: Loading child library ..\n");
+      std::cout << "KokkosP: Next library to call: " << nextLibrary << '\n';
+      std::cout << "KokkosP: Loading child library ..\n";
     }
 
     void* childLibrary = dlopen(nextLibrary, RTLD_NOW | RTLD_GLOBAL);
 
     if (NULL == childLibrary) {
-      fprintf(stderr, "KokkosP: Error: Unable to load: %s (Error=%s)\n",
-              nextLibrary, dlerror());
+      std::cerr << "KokkosP: Error: Unable to load: " << nextLibrary << " (Error=" << dlerror() << ")\n";
       exit(-1);
     } else {
       beginForCallee =
@@ -167,19 +166,19 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
       }
 
       if (tool_verbosity > 0) {
-        printf("KokkosP: Function Status:\n");
-        printf("KokkosP: begin-parallel-for:      %s\n",
-               (beginForCallee == NULL) ? "no" : "yes");
-        printf("KokkosP: begin-parallel-scan:     %s\n",
-               (beginScanCallee == NULL) ? "no" : "yes");
-        printf("KokkosP: begin-parallel-reduce:   %s\n",
-               (beginReduceCallee == NULL) ? "no" : "yes");
-        printf("KokkosP: end-parallel-for:        %s\n",
-               (endForCallee == NULL) ? "no" : "yes");
-        printf("KokkosP: end-parallel-scan:       %s\n",
-               (endScanCallee == NULL) ? "no" : "yes");
-        printf("KokkosP: end-parallel-reduce:     %s\n",
-               (endReduceCallee == NULL) ? "no" : "yes");
+        std::cout << "KokkosP: Function Status:\n";
+        std::cout << "KokkosP: begin-parallel-for:      " <<
+               ((beginForCallee == NULL) ? "no" : "yes")<< '\n';
+        std::cout << "KokkosP: begin-parallel-scan:     " <<
+               ((beginScanCallee == NULL) ? "no" : "yes")<< '\n';
+        std::cout << "KokkosP: begin-parallel-reduce:   " <<
+               ((beginReduceCallee == NULL) ? "no" : "yes")<< '\n';
+        std::cout << "KokkosP: end-parallel-for:        " <<
+               ((endForCallee == NULL) ? "no" : "yes")<< '\n';
+        std::cout << "KokkosP: end-parallel-scan:       " <<
+               ((endScanCallee == NULL) ? "no" : "yes")<< '\n';
+        std::cout << "KokkosP: end-parallel-reduce:     " <<
+               ((endReduceCallee == NULL) ? "no" : "yes") << '\n';
       }
     }
   }
@@ -191,17 +190,16 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
   if (0 > tool_seed) {
     srand(time(NULL));
     if (tool_verbosity > 0) {
-      printf(
+      std::cout <<
           "KokkosP: Seeding random number generator using clock for "
-          "random sampling.\n");
+          "random sampling.\n";
     }
   } else {
     srand(tool_seed);
     if (tool_verbosity > 0) {
-      printf(
-          "KokkosP: Seeding random number generator using seed %u for "
-          "random sampling.\n",
-          tool_seed);
+      std::cout <<
+          "KokkosP: Seeding random number generator using seed " << tool_seed << " for "
+          "random sampling.\n";
     }
   }
 
@@ -213,24 +211,24 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     //  Connector reasons about probability as a double between 0.0 and 1.0.
     tool_prob_num = atof(tool_probability);
     if (tool_prob_num > 100.0) {
-      printf(
+      std::cout <<
           "KokkosP: The sampling probability value is set to be greater than "
           "100.0. "
           "The probability for the sampler will be set to 100 percent; all of "
           "the "
-          "invocations of a Kokkos kernel will be profiled.\n");
+          "invocations of a Kokkos kernel will be profiled.\n";
       tool_prob_num = 100.0;
     } else if (tool_prob_num < 0.0) {
-      printf(
+      std::cout <<
           "KokkosP: The sampling probability value is set to be a negative "
           "number. The "
           "sampler's probability will be set to 0 percent; none of the "
           "invocations of "
-          "a Kokkos kernel will be profiled.\n");
+          "a Kokkos kernel will be profiled.\n";
       tool_prob_num = 0.0;
     }
     if (tool_verbosity > 0) {
-      printf("KokkosP: Probability for the sampler set to: %f\n", tool_prob_num);
+      std::cout << "KokkosP: Probability for the sampler set to: " << tool_prob_num << '\n';
     }  
     kernelSampleSkip = 1;
     return;
@@ -241,25 +239,24 @@ void kokkosp_init_library(const int loadSeq, const uint64_t interfaceVer,
     tool_prob_num = 100.0;
     kernelSampleSkip = atoi(tool_sample) + 1;
     if (tool_verbosity > 0) {
-      printf("KokkosP: Sampling rate set to: %s\n", tool_sample);
+      std::cout << "KokkosP: Sampling rate set to: " << tool_sample << '\n';
     }
     return;
   }
 
     if (tool_verbosity > 0) {
-      printf(
+      std::cout <<
           "KokkosP: Neither the probability "
-          "nor the skip rate for sampling were set...\n");
+          "nor the skip rate for sampling were set...\n";
     }
     tool_prob_num = 10.0;
     kernelSampleSkip = 1;
     if (tool_verbosity > 0) {
-      printf(
+      std::cout <<
           "KokkosP: The probability "
-          "for the sampler is set to the default of %f percent. The skip rate "
+          "for the sampler is set to the default of " <<tool_prob_num <<" percent. The skip rate "
           "for sampler"
-          "will not be used.\n",
-          tool_prob_num);
+          "will not be used.\n";
     }
     kernelSampleSkip = 1;
 }
@@ -276,8 +273,7 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
   if ((invocationNum % kernelSampleSkip) == 0) {
   if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
       if (tool_verbosity > 0) {
-        printf("KokkosP: sample %llu calling child-begin function...\n",
-               (unsigned long long)(*kID));
+        std::cout << "KokkosP: sample " << *kID << " calling child-begin function...\n";
       }
       if (NULL != beginForCallee) {
         if (tool_globFence) {
@@ -286,8 +282,7 @@ void kokkosp_begin_parallel_for(const char* name, const uint32_t devID,
         uint64_t nestedkID = 0;
         (*beginForCallee)(name, devID, &nestedkID);
         if (tool_verbosity > 0) {
-          printf("KokkosP: sample %llu finished with child-begin function.\n",
-                 (unsigned long long)(*kID));
+          std::cout << "KokkosP: sample " << *kID << " finished with child-begin function.\n";
         }
         infokIDSample.insert({*kID, nestedkID});
       }
@@ -300,8 +295,7 @@ if (NULL != endForCallee) {
  if (!(infokIDSample.find(kID) == infokIDSample.end())) {
       uint64_t retrievedNestedkID = infokIDSample[kID];
       if (tool_verbosity > 0) {
-        printf("KokkosP: sample %llu calling child-end function...\n",
-               (unsigned long long)(kID));
+        std::cout << "KokkosP: sample " << kID << " calling child-end function...\n";
       }
       if (tool_globFence) {
         invoke_ktools_fence(0);
@@ -320,8 +314,7 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
   if ((invocationNum % kernelSampleSkip) == 0) {
     if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
       if (tool_verbosity > 0) {
-        printf("KokkosP: sample %llu calling child-begin function...\n",
-               (unsigned long long)(*kID));
+        std::cout << "KokkosP: sample " << *kID << " calling child-begin function...\n";
       }
       if (NULL != beginScanCallee) {
         uint64_t nestedkID = 0;
@@ -330,8 +323,7 @@ void kokkosp_begin_parallel_scan(const char* name, const uint32_t devID,
         }
         (*beginScanCallee)(name, devID, &nestedkID);
         if (tool_verbosity > 0) {
-          printf("KokkosP: sample %llu finished with child-begin function.\n",
-                 (unsigned long long)(*kID));
+          std::cout << "KokkosP: sample " << *kID << " finished with child-begin function.\n";
         }
         infokIDSample.insert({*kID, nestedkID});
       }
@@ -344,8 +336,7 @@ void kokkosp_end_parallel_scan(const uint64_t kID) {
     if (!(infokIDSample.find(kID) == infokIDSample.end())) {
       uint64_t retrievedNestedkID = infokIDSample[kID];
       if (tool_verbosity > 0) {
-        printf("KokkosP: sample %llu calling child-end function...\n",
-               (unsigned long long)(kID));
+        std::cout << "KokkosP: sample " << kID << " calling child-end function...\n";
       }
       if (tool_globFence) {
         invoke_ktools_fence(0);
@@ -364,8 +355,7 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
   if ((invocationNum % kernelSampleSkip) == 0) {
     if ((rand() / (1.0 * RAND_MAX)) < (tool_prob_num / 100.0)) {
       if (tool_verbosity > 0) {
-        printf("KokkosP: sample %llu calling child-begin function...\n",
-               (unsigned long long)(*kID));
+        std::cout << "KokkosP: sample " << *kID << " calling child-begin function...\n";
       }
       if (NULL != beginReduceCallee) {
         uint64_t nestedkID = 0;
@@ -374,8 +364,7 @@ void kokkosp_begin_parallel_reduce(const char* name, const uint32_t devID,
         }
         (*beginReduceCallee)(name, devID, &nestedkID);
         if (tool_verbosity > 0) {
-          printf("KokkosP: sample %llu finished with child-begin function.\n",
-                 (unsigned long long)(*kID));
+          std::cout << "KokkosP: sample " << *kID << " finished with child-begin function.\n";
         }
         infokIDSample.insert({*kID, nestedkID});
       }
@@ -388,8 +377,7 @@ void kokkosp_end_parallel_reduce(const uint64_t kID) {
     if (!(infokIDSample.find(kID) == infokIDSample.end())) {
       uint64_t retrievedNestedkID = infokIDSample[kID];
       if (tool_verbosity > 0) {
-        printf("KokkosP: sample %llu calling child-end function...\n",
-               (unsigned long long)(kID));
+        std::cout << "KokkosP: sample " << kID << " calling child-end function...\n";
       }
       if (tool_globFence) {
         invoke_ktools_fence(0);

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <limits>
 #include <cstring>
+#include <iostream>
 
 std::vector<std::string> regions;
 static uint64_t uniqID;
@@ -28,10 +29,10 @@ struct SpaceHandle {
 };
 
 void kokkosp_print_region_stack_indent(const int level) {
-  printf("KokkosP: ");
+  std::cout << "KokkosP: ";
 
   for (int i = 0; i < level; i++) {
-    printf("  ");
+    std::cout << "  ";
   }
 }
 
@@ -40,7 +41,7 @@ int kokkosp_print_region_stack() {
 
   for (auto regItr = regions.begin(); regItr != regions.end(); regItr++) {
     kokkosp_print_region_stack_indent(level);
-    printf("%s\n", (*regItr).c_str());
+    std::cout << *regItr << '\n';
 
     level++;
   }
@@ -52,15 +53,13 @@ extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t /*devInfoCount*/,
                                      void* /*deviceInfo*/) {
-  printf(
-      "KokkosP: Kernel Logger Library Initialized (sequence is %d, version: "
-      "%llu)\n",
-      loadSeq, (unsigned long long)(interfaceVer));
+  std::cout << "KokkosP: Kernel Logger Library Initialized (sequence is "
+            << loadSeq << ", version: " << interfaceVer << ")\n";
   uniqID = 0;
 }
 
 extern "C" void kokkosp_finalize_library() {
-  printf("KokkosP: Kokkos library finalization called.\n");
+  std::cout << "KokkosP: Kokkos library finalization called.\n";
 }
 
 extern "C" void kokkosp_begin_parallel_for(const char* name,
@@ -68,20 +67,17 @@ extern "C" void kokkosp_begin_parallel_for(const char* name,
                                            uint64_t* kID) {
   *kID = uniqID++;
 
-  printf(
-      "KokkosP: Executing parallel-for kernel on device %d with unique "
-      "execution identifier %llu\n",
-      devID, (unsigned long long)(*kID));
+  std::cout << "KokkosP: Executing parallel-for kernel on device " << devID
+            << " with unique execution identifier " << *kID << '\n';
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);
-
-  printf("    %s\n", name);
+  std::cout << "    " << name << '\n';
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-  printf("KokkosP: Execution of kernel %llu is completed.\n",
-         (unsigned long long)(kID));
+  std::abort();
+  std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
 }
 
 extern "C" void kokkosp_begin_parallel_scan(const char* name,
@@ -89,20 +85,17 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name,
                                             uint64_t* kID) {
   *kID = uniqID++;
 
-  printf(
-      "KokkosP: Executing parallel-scan kernel on device %d with unique "
-      "execution identifier %llu\n",
-      devID, (unsigned long long)(*kID));
+  std::cout << "KokkosP: Executing parallel-scan kernel on device " << devID
+            << " with unique execution identifier " << *kID << '\n';
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);
 
-  printf("    %s\n", name);
+  std::cout << "    " << name << '\n';
 }
 
 extern "C" void kokkospk_end_parallel_scan(const uint64_t kID) {
-  printf("KokkosP: Execution of kernel %llu is completed.\n",
-         (unsigned long long)(kID));
+  std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
 }
 
 extern "C" void kokkosp_begin_parallel_reduce(const char* name,
@@ -110,20 +103,17 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name,
                                               uint64_t* kID) {
   *kID = uniqID++;
 
-  printf(
-      "KokkosP: Executing parallel-reduce kernel on device %d with unique "
-      "execution identifier %llu\n",
-      devID, (unsigned long long)(*kID));
+  std::cout << "KokkosP: Executing parallel-reduce kernel on device " << devID
+            << " with unique execution identifier " << *kID << '\n';
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);
 
-  printf("    %s\n", name);
+  std::cout << "    " << name << '\n';
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-  printf("KokkosP: Execution of kernel %llu is completed.\n",
-         (unsigned long long)(kID));
+  std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
@@ -139,15 +129,13 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
   } else {
     *kID = uniqID++;
 
-    printf(
-        "KokkosP: Executing fence on device %d with unique execution "
-        "identifier %llu\n",
-        devID, (unsigned long long)(*kID));
+    std::cout << "KokkosP: Executing fence on device " << devID
+              << " with unique execution identifier " << kID << '\n';
 
     int level = kokkosp_print_region_stack();
     kokkosp_print_region_stack_indent(level);
 
-    printf("    %s\n", name);
+    std::cout << "    " << name << '\n';
   }
 }
 
@@ -156,13 +144,12 @@ extern "C" void kokkosp_end_fence(const uint64_t kID) {
   // dealing with the application's fence, which we filtered out in the callback
   // for fences
   if (kID != std::numeric_limits<uint64_t>::max()) {
-    printf("KokkosP: Execution of fence %llu is completed.\n",
-           (unsigned long long)(kID));
+    std::cout << "KokkosP: Execution of fence %llu is completed.\n";
   }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {
-  printf("KokkosP: Entering profiling region: %s\n", regionName);
+  std::cout << "KokkosP: Entering profiling region: " << regionName << '\n';
 
   std::string regionNameStr(regionName);
   regions.push_back(regionNameStr);
@@ -170,21 +157,22 @@ extern "C" void kokkosp_push_profile_region(char* regionName) {
 
 extern "C" void kokkosp_pop_profile_region() {
   if (regions.size() > 0) {
-    printf("KokkosP: Exiting profiling region: %s\n", regions.back().c_str());
+    std::cout << "KokkosP: Exiting profiling region: " << regions.back()
+              << '\n';
     regions.pop_back();
   }
 }
 
 extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name,
                                       void* ptr, uint64_t size) {
-  printf("KokkosP: Allocate<%s> name: %s pointer: %p size: %llu\n", handle.name,
-         name, ptr, (unsigned long long)(size));
+  std::cout << "KokkosP: Allocate<" << handle.name << "> name: " << name
+            << " pointer: " << ptr << " size: " << size << '\n';
 }
 
 extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name,
                                         void* ptr, uint64_t size) {
-  printf("KokkosP: Deallocate<%s> name: %s pointer: %p size: %llu\n",
-         handle.name, name, ptr, (unsigned long long)(size));
+  std::cout << "KokkosP: Deallocate<" << handle.name << "> name: " << name
+            << " pointer: " << ptr << " size: " << size << '\n';
 }
 
 extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
@@ -193,9 +181,8 @@ extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
                                         SpaceHandle src_handle,
                                         const char* src_name,
                                         const void* src_ptr, uint64_t size) {
-  printf(
-      "KokkosP: DeepCopy<%s,%s> DST(name: %s pointer: %p) SRC(name: %s pointer "
-      "%p) Size: %llu\n",
-      dst_handle.name, src_handle.name, dst_name, dst_ptr, src_name, src_ptr,
-      (unsigned long long)(size));
+  std::cout << "KokkosP: DeepCopy<" << dst_handle.name << ',' << src_handle.name
+            << "> DST(name: " << dst_name << " pointer: " << dst_ptr
+            << ") SRC(name: " << src_name << " pointer " << src_ptr
+            << ") Size: " << size << '\n';
 }

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -20,7 +20,6 @@
 #include <string>
 #include <limits>
 #include <cstring>
-#include <iostream>
 
 std::vector<std::string> regions;
 static uint64_t uniqID;
@@ -29,10 +28,10 @@ struct SpaceHandle {
 };
 
 void kokkosp_print_region_stack_indent(const int level) {
-  std::cout << "KokkosP: ";
+  printf("KokkosP: ");
 
   for (int i = 0; i < level; i++) {
-    std::cout << "  ";
+    printf("  ");
   }
 }
 
@@ -41,7 +40,7 @@ int kokkosp_print_region_stack() {
 
   for (auto regItr = regions.begin(); regItr != regions.end(); regItr++) {
     kokkosp_print_region_stack_indent(level);
-    std::cout << *regItr << '\n';
+    printf("%s\n", (*regItr).c_str());
 
     level++;
   }
@@ -53,13 +52,15 @@ extern "C" void kokkosp_init_library(const int loadSeq,
                                      const uint64_t interfaceVer,
                                      const uint32_t /*devInfoCount*/,
                                      void* /*deviceInfo*/) {
-  std::cout << "KokkosP: Kernel Logger Library Initialized (sequence is "
-            << loadSeq << ", version: " << interfaceVer << ")\n";
+  printf(
+      "KokkosP: Kernel Logger Library Initialized (sequence is %d, version: "
+      "%llu)\n",
+      loadSeq, (unsigned long long)(interfaceVer));
   uniqID = 0;
 }
 
 extern "C" void kokkosp_finalize_library() {
-  std::cout << "KokkosP: Kokkos library finalization called.\n";
+  printf("KokkosP: Kokkos library finalization called.\n");
 }
 
 extern "C" void kokkosp_begin_parallel_for(const char* name,
@@ -67,16 +68,20 @@ extern "C" void kokkosp_begin_parallel_for(const char* name,
                                            uint64_t* kID) {
   *kID = uniqID++;
 
-  std::cout << "KokkosP: Executing parallel-for kernel on device " << devID
-            << " with unique execution identifier " << *kID << '\n';
+  printf(
+      "KokkosP: Executing parallel-for kernel on device %d with unique "
+      "execution identifier %llu\n",
+      devID, (unsigned long long)(*kID));
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);
-  std::cout << "    " << name << '\n';
+
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-  std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
+  printf("KokkosP: Execution of kernel %llu is completed.\n",
+         (unsigned long long)(kID));
 }
 
 extern "C" void kokkosp_begin_parallel_scan(const char* name,
@@ -84,17 +89,20 @@ extern "C" void kokkosp_begin_parallel_scan(const char* name,
                                             uint64_t* kID) {
   *kID = uniqID++;
 
-  std::cout << "KokkosP: Executing parallel-scan kernel on device " << devID
-            << " with unique execution identifier " << *kID << '\n';
+  printf(
+      "KokkosP: Executing parallel-scan kernel on device %d with unique "
+      "execution identifier %llu\n",
+      devID, (unsigned long long)(*kID));
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);
 
-  std::cout << "    " << name << '\n';
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkospk_end_parallel_scan(const uint64_t kID) {
-  std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
+  printf("KokkosP: Execution of kernel %llu is completed.\n",
+         (unsigned long long)(kID));
 }
 
 extern "C" void kokkosp_begin_parallel_reduce(const char* name,
@@ -102,17 +110,20 @@ extern "C" void kokkosp_begin_parallel_reduce(const char* name,
                                               uint64_t* kID) {
   *kID = uniqID++;
 
-  std::cout << "KokkosP: Executing parallel-reduce kernel on device " << devID
-            << " with unique execution identifier " << *kID << '\n';
+  printf(
+      "KokkosP: Executing parallel-reduce kernel on device %d with unique "
+      "execution identifier %llu\n",
+      devID, (unsigned long long)(*kID));
 
   int level = kokkosp_print_region_stack();
   kokkosp_print_region_stack_indent(level);
 
-  std::cout << "    " << name << '\n';
+  printf("    %s\n", name);
 }
 
 extern "C" void kokkosp_end_parallel_reduce(const uint64_t kID) {
-  std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
+  printf("KokkosP: Execution of kernel %llu is completed.\n",
+         (unsigned long long)(kID));
 }
 
 extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
@@ -128,13 +139,15 @@ extern "C" void kokkosp_begin_fence(const char* name, const uint32_t devID,
   } else {
     *kID = uniqID++;
 
-    std::cout << "KokkosP: Executing fence on device " << devID
-              << " with unique execution identifier " << kID << '\n';
+    printf(
+        "KokkosP: Executing fence on device %d with unique execution "
+        "identifier %llu\n",
+        devID, (unsigned long long)(*kID));
 
     int level = kokkosp_print_region_stack();
     kokkosp_print_region_stack_indent(level);
 
-    std::cout << "    " << name << '\n';
+    printf("    %s\n", name);
   }
 }
 
@@ -143,12 +156,13 @@ extern "C" void kokkosp_end_fence(const uint64_t kID) {
   // dealing with the application's fence, which we filtered out in the callback
   // for fences
   if (kID != std::numeric_limits<uint64_t>::max()) {
-    std::cout << "KokkosP: Execution of fence %llu is completed.\n";
+    printf("KokkosP: Execution of fence %llu is completed.\n",
+           (unsigned long long)(kID));
   }
 }
 
 extern "C" void kokkosp_push_profile_region(char* regionName) {
-  std::cout << "KokkosP: Entering profiling region: " << regionName << '\n';
+  printf("KokkosP: Entering profiling region: %s\n", regionName);
 
   std::string regionNameStr(regionName);
   regions.push_back(regionNameStr);
@@ -156,22 +170,21 @@ extern "C" void kokkosp_push_profile_region(char* regionName) {
 
 extern "C" void kokkosp_pop_profile_region() {
   if (regions.size() > 0) {
-    std::cout << "KokkosP: Exiting profiling region: " << regions.back()
-              << '\n';
+    printf("KokkosP: Exiting profiling region: %s\n", regions.back().c_str());
     regions.pop_back();
   }
 }
 
 extern "C" void kokkosp_allocate_data(SpaceHandle handle, const char* name,
                                       void* ptr, uint64_t size) {
-  std::cout << "KokkosP: Allocate<" << handle.name << "> name: " << name
-            << " pointer: " << ptr << " size: " << size << '\n';
+  printf("KokkosP: Allocate<%s> name: %s pointer: %p size: %llu\n", handle.name,
+         name, ptr, (unsigned long long)(size));
 }
 
 extern "C" void kokkosp_deallocate_data(SpaceHandle handle, const char* name,
                                         void* ptr, uint64_t size) {
-  std::cout << "KokkosP: Deallocate<" << handle.name << "> name: " << name
-            << " pointer: " << ptr << " size: " << size << '\n';
+  printf("KokkosP: Deallocate<%s> name: %s pointer: %p size: %llu\n",
+         handle.name, name, ptr, (unsigned long long)(size));
 }
 
 extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
@@ -180,8 +193,9 @@ extern "C" void kokkosp_begin_deep_copy(SpaceHandle dst_handle,
                                         SpaceHandle src_handle,
                                         const char* src_name,
                                         const void* src_ptr, uint64_t size) {
-  std::cout << "KokkosP: DeepCopy<" << dst_handle.name << ',' << src_handle.name
-            << "> DST(name: " << dst_name << " pointer: " << dst_ptr
-            << ") SRC(name: " << src_name << " pointer " << src_ptr
-            << ") Size: " << size << '\n';
+  printf(
+      "KokkosP: DeepCopy<%s,%s> DST(name: %s pointer: %p) SRC(name: %s pointer "
+      "%p) Size: %llu\n",
+      dst_handle.name, src_handle.name, dst_name, dst_ptr, src_name, src_ptr,
+      (unsigned long long)(size));
 }

--- a/debugging/kernel-logger/kp_kernel_logger.cpp
+++ b/debugging/kernel-logger/kp_kernel_logger.cpp
@@ -76,7 +76,6 @@ extern "C" void kokkosp_begin_parallel_for(const char* name,
 }
 
 extern "C" void kokkosp_end_parallel_for(const uint64_t kID) {
-  std::abort();
   std::cout << "KokkosP: Execution of kernel " << kID << " is completed.\n";
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 #   KOKKOS_TOOLS_GLOBALFENCES : test environment receives the variable 'KOKKOS_TOOLS_GLOBALFENCES' that is set as the value of 1 to turn the tool's auto-fencing on. 
 
 function(kp_add_executable_and_test)
-	cmake_parse_arguments(kaeat_args "" "TARGET_NAME;SOURCE_FILE;KOKKOS_TOOLS_LIBS;KOKKOS_TOOLS_LIBS2;KOKKOS_TOOLS_SAMPLER_VERBOSE;KOKKOS_TOOLS_GLOBALFENCES;KOKKOS_TOOLS_SAMPLER_SKIP" "" ${ARGN})
+    cmake_parse_arguments(kaeat_args "" "TARGET_NAME;SOURCE_FILE;KOKKOS_TOOLS_SAMPLER_VERBOSE;KOKKOS_TOOLS_GLOBALFENCES;KOKKOS_TOOLS_SAMPLER_SKIP" "KOKKOS_TOOLS_LIBS" ${ARGN})
 
     if(NOT DEFINED kaeat_args_TARGET_NAME)
         message(FATAL_ERROR "'TARGET_NAME' is a required argument.")
@@ -34,54 +34,50 @@ function(kp_add_executable_and_test)
             kokkostools test_common
     )
 
+    MESSAGE(STATUS "TARGET_NAME: ${kaeat_args_TARGET_NAME}, KOKKOS_TOOLS_LIBS: ${kaeat_args_KOKKOS_TOOLS_LIBS}")
+
     add_test(
         NAME ${kaeat_args_TARGET_NAME}
         COMMAND $<TARGET_FILE:${kaeat_args_TARGET_NAME}>
     )
 
     if(DEFINED kaeat_args_KOKKOS_TOOLS_LIBS)
-     if(DEFINED kaeat_args_KOKKOS_TOOLS_LIBS2)
+        set(TOOL_LIBS_FILES)
+        foreach(TOOL_LIB ${kaeat_args_KOKKOS_TOOLS_LIBS})
+          set(TOOL_LIBS_FILES "${TOOL_LIBS_FILES}\;$<TARGET_FILE:${TOOL_LIB}>")
+        endforeach()
+
         set_property(
             TEST ${kaeat_args_TARGET_NAME}
-            APPEND
-            PROPERTY
-	    ENVIRONMENT "KOKKOS_TOOLS_LIBS=$<TARGET_FILE:${kaeat_args_KOKKOS_TOOLS_LIBS}>\;$<TARGET_FILE:${kaeat_args_KOKKOS_TOOLS_LIBS2}>"
+            APPEND PROPERTY ENVIRONMENT "KOKKOS_TOOLS_LIBS=${TOOL_LIBS_FILES}"
         )
-      else() 
-        set_property(
-		TEST ${kaeat_args_TARGET_NAME}
-	        APPEND
-		PROPERTY
-               ENVIRONMENT "KOKKOS_TOOLS_LIBS=$<TARGET_FILE:${kaeat_args_KOKKOS_TOOLS_LIBS}>;"        
-	)
-     endif()
     endif()
     
     if(DEFINED kaeat_args_KOKKOS_TOOLS_SAMPLER_VERBOSE)
-	 set_property(
-		TEST ${kaeat_args_TARGET_NAME}
-		APPEND
-		PROPERTY
-		ENVIRONMENT "KOKKOS_TOOLS_SAMPLER_VERBOSE=${kaeat_args_KOKKOS_TOOLS_SAMPLER_VERBOSE}"
-	       )
+     set_property(
+        TEST ${kaeat_args_TARGET_NAME}
+        APPEND
+        PROPERTY
+        ENVIRONMENT "KOKKOS_TOOLS_SAMPLER_VERBOSE=${kaeat_args_KOKKOS_TOOLS_SAMPLER_VERBOSE}"
+           )
      endif()
 
      if(DEFINED kaeat_args_KOKKOS_TOOLS_GLOBALFENCES)
         set_property(
-		TEST ${kaeat_args_TARGET_NAME}
-		APPEND
-		PROPERTY
-		ENVIRONMENT "KOKKOS_TOOLS_GLOBALFENCES=${kaeat_args_KOKKOS_TOOLS_GLOBALFENCES}"
+        TEST ${kaeat_args_TARGET_NAME}
+        APPEND
+        PROPERTY
+        ENVIRONMENT "KOKKOS_TOOLS_GLOBALFENCES=${kaeat_args_KOKKOS_TOOLS_GLOBALFENCES}"
                )
       endif()
      
      if (DEFINED kaeat_args_KOKKOS_TOOLS_SAMPLER_SKIP)
-	     set_property(
-		     TEST ${kaeat_args_TARGET_NAME}
-		     APPEND 
-		     PROPERTY
-		     ENVIRONMENT "KOKKOS_TOOLS_SAMPLER_SKIP=${kaeat_args_KOKKOS_TOOLS_SAMPLER_SKIP}"
-	     )
+         set_property(
+             TEST ${kaeat_args_TARGET_NAME}
+             APPEND 
+             PROPERTY
+             ENVIRONMENT "KOKKOS_TOOLS_SAMPLER_SKIP=${kaeat_args_KOKKOS_TOOLS_SAMPLER_SKIP}"
+         )
 
      endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,8 +34,6 @@ function(kp_add_executable_and_test)
             kokkostools test_common
     )
 
-    MESSAGE(STATUS "TARGET_NAME: ${kaeat_args_TARGET_NAME}, KOKKOS_TOOLS_LIBS: ${kaeat_args_KOKKOS_TOOLS_LIBS}")
-
     add_test(
         NAME ${kaeat_args_TARGET_NAME}
         COMMAND $<TARGET_FILE:${kaeat_args_TARGET_NAME}>
@@ -44,8 +42,9 @@ function(kp_add_executable_and_test)
     if(DEFINED kaeat_args_KOKKOS_TOOLS_LIBS)
         set(TOOL_LIBS_FILES)
         foreach(TOOL_LIB ${kaeat_args_KOKKOS_TOOLS_LIBS})
-          set(TOOL_LIBS_FILES "${TOOL_LIBS_FILES}\;$<TARGET_FILE:${TOOL_LIB}>")
+          list(APPEND TOOL_LIBS_FILES "$<TARGET_FILE:${TOOL_LIB}>")
         endforeach()
+        string(REPLACE ";" "\;" TOOL_LIBS_FILES "${TOOL_LIBS_FILES}")
 
         set_property(
             TEST ${kaeat_args_TARGET_NAME}

--- a/tests/sampler/CMakeLists.txt
+++ b/tests/sampler/CMakeLists.txt
@@ -3,8 +3,8 @@ kp_add_executable_and_test(
     SOURCE_FILE       test_randomized_sampling.cpp
     KOKKOS_TOOLS_LIBS kp_kokkos_sampler
     KOKKOS_TOOLS_LIBS2 kp_kernel_logger
-    KOKKOS_TOOLS_SAMPLER_VERBOSE 1
-    KOKKOS_TOOLS_SAMPLER_SKIP 100
+    KOKKOS_TOOLS_SAMPLER_VERBOSE 2
+    KOKKOS_TOOLS_SAMPLER_SKIP 50
     KOKKOS_TOOLS_SAMPLER_PROB 100.0
     KOKKOS_TOOLS_GLOBALFENCES 1
 )

--- a/tests/sampler/CMakeLists.txt
+++ b/tests/sampler/CMakeLists.txt
@@ -1,10 +1,8 @@
 kp_add_executable_and_test(
     TARGET_NAME       test_sampler_randomizedsampling
     SOURCE_FILE       test_randomized_sampling.cpp
-    KOKKOS_TOOLS_LIBS kp_kokkos_sampler
-    KOKKOS_TOOLS_LIBS2 kp_kernel_logger
+    KOKKOS_TOOLS_LIBS kp_kokkos_sampler kp_kernel_logger
     KOKKOS_TOOLS_SAMPLER_VERBOSE 2
     KOKKOS_TOOLS_SAMPLER_SKIP 50
-    KOKKOS_TOOLS_SAMPLER_PROB 100.0
     KOKKOS_TOOLS_GLOBALFENCES 1
 )

--- a/tests/sampler/test_randomized_sampling.cpp
+++ b/tests/sampler/test_randomized_sampling.cpp
@@ -10,8 +10,8 @@ struct Tester {
   template <typename execution_space>
   explicit Tester(const execution_space& space) {
     //! Explicitly launch a kernel with a name, and run it 150 times with kernel
-    //! logger. Use a periodic sampling with skip rate 101. This should print
-    //! out 1 invocation, and there is a single matcher with a regular
+    //! logger. Use a periodic sampling with skip rate 51. This should print
+    //! out 2 invocation, and there is a single matcher with a regular
     //! expression to check this.
 
     for (int iter = 0; iter < 150; iter++) {
@@ -25,7 +25,8 @@ struct Tester {
 };
 
 static const std::vector<std::string> matchers{
-    "(.*) KokkosP: Execution of kernel 101 is completed (.*)"};
+    "(.*)KokkosP: Execution of kernel 0 is completed(.*)",
+    "(.*)KokkosP: Execution of kernel 1 is completed(.*)"};
 
 /**
  * @test This test checks that the tool effectively samples.

--- a/tests/sampler/test_randomized_sampling.cpp
+++ b/tests/sampler/test_randomized_sampling.cpp
@@ -25,8 +25,14 @@ struct Tester {
 };
 
 static const std::vector<std::string> matchers{
-    "(.*)KokkosP: Execution of kernel 0 is completed(.*)",
-    "(.*)KokkosP: Execution of kernel 1 is completed(.*)"};
+"(.*)KokkosP: sample 51 calling child-begin function...(.*)",
+"(.*)KokkosP: sample 51 finished with child-begin function.(.*)",
+"(.*)KokkosP: sample 51 calling child-end function...(.*)",
+"(.*)KokkosP: sample 51 calling child-end function.(.*)",
+"(.*)KokkosP: sample 102 calling child-begin function...(.*)",
+"(.*)KokkosP: sample 102 finished with child-begin function.(.*)",
+"(.*)KokkosP: sample 102 calling child-end function...(.*)",
+"(.*)KokkosP: sample 102 calling child-end function.(.*)"};
 
 /**
  * @test This test checks that the tool effectively samples.

--- a/tests/sampler/test_randomized_sampling.cpp
+++ b/tests/sampler/test_randomized_sampling.cpp
@@ -25,14 +25,14 @@ struct Tester {
 };
 
 static const std::vector<std::string> matchers{
-"(.*)KokkosP: sample 51 calling child-begin function...(.*)",
-"(.*)KokkosP: sample 51 finished with child-begin function.(.*)",
-"(.*)KokkosP: sample 51 calling child-end function...(.*)",
-"(.*)KokkosP: sample 51 calling child-end function.(.*)",
-"(.*)KokkosP: sample 102 calling child-begin function...(.*)",
-"(.*)KokkosP: sample 102 finished with child-begin function.(.*)",
-"(.*)KokkosP: sample 102 calling child-end function...(.*)",
-"(.*)KokkosP: sample 102 calling child-end function.(.*)"};
+    "(.*)KokkosP: sample 51 calling child-begin function...(.*)",
+    "(.*)KokkosP: sample 51 finished with child-begin function.(.*)",
+    "(.*)KokkosP: sample 51 calling child-end function...(.*)",
+    "(.*)KokkosP: sample 51 calling child-end function.(.*)",
+    "(.*)KokkosP: sample 102 calling child-begin function...(.*)",
+    "(.*)KokkosP: sample 102 finished with child-begin function.(.*)",
+    "(.*)KokkosP: sample 102 calling child-end function...(.*)",
+    "(.*)KokkosP: sample 102 calling child-end function.(.*)"};
 
 /**
  * @test This test checks that the tool effectively samples.


### PR DESCRIPTION
Some inspirations for fixing https://github.com/kokkos/kokkos-tools/pull/213.
- One of the commits replaces `printf` in `kernel-logger`, these changes are reverted in the last commit
- Another commit converts the sampler to using `printf` so we only test messages coming from the sampler
- Fix multiple tools libraries in tests
- Fix handling of probability sampling when a skip rate is present (I removed `KOKKOS_TOOLS_SAMPLER_PROB` from the test since it wasn't recognized in the `CTest` setup anyway.

Feel free to decide what you want to adopt from these changes.